### PR TITLE
fix: pin upload-sarif-github-action to latest SHA (KICS/Trivy disabled)

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -26,6 +26,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action/scan@27fad937a82cb810d954795f7d29c1702be17960
+        uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin `upload-sarif-github-action` to latest SHA (`07dad711`) which has KICS and Trivy disabled
- Previous pin still had KICS active; while SHA pinning protected against the TeamPCP tag-repointing attack, updating removes any residual risk

## Context
On 2026-03-23, `checkmarx/kics-github-action` was compromised by TeamPCP (credential-stealing malware). `aquasecurity/trivy-action` was similarly compromised on 2026-03-19. The shared `upload-sarif-github-action` has been updated to disable both tools. This PR updates the pin to that version.

See: https://www.wiz.io/blog/teampcp-attack-kics-github-action